### PR TITLE
Update SS58Prefix to 149 (mb***)

### DIFF
--- a/s-node/runtime/src/lib.rs
+++ b/s-node/runtime/src/lib.rs
@@ -271,7 +271,7 @@ pub const BABE_GENESIS_EPOCH_CONFIG: sp_consensus_babe::BabeEpochConfiguration =
 parameter_types! {
 	pub const Version: RuntimeVersion = VERSION;
 	pub const BlockHashCount: BlockNumber = 4800; // 4hrs
-	pub const SS58Prefix: u16 = 258;
+	pub const SS58Prefix: u8 = 149;
 }
 
 impl frame_system::Config for Runtime {


### PR DESCRIPTION
solves ERROR: balances.transferKeepAlive -32602: Invalid params: UnknownVersion. #17